### PR TITLE
feat(trace): save provider reasoning payloads

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -95,10 +95,21 @@ def _messages_to_anthropic(messages):
     return system_text, out
 
 
+def _openai_reasoning_payload(message):
+    """Return provider-supplied reasoning fields without affecting response text."""
+    extras = getattr(message, "model_extra", None) or {}
+    fields = {}
+    for name in ("reasoning_content", "reasoning", "reasoning_details"):
+        value = extras.get(name, getattr(message, name, None))
+        if value is not None:
+            fields[name] = value
+    return {"provider_format": "openai-compatible", "fields": fields} if fields else None
+
+
 def _anthropic_create(model, messages):
     """Send messages via an Anthropic-native /v1/messages endpoint with prompt caching.
 
-    Returns (text, usage_dict). usage_dict matches anthropic-style:
+    Returns (text, usage_dict, reasoning_payload). usage_dict matches anthropic-style:
       {input_tokens, cache_creation_input_tokens, cache_read_input_tokens, output_tokens, ...}
     """
     system_text, an_msgs = _messages_to_anthropic(messages)
@@ -146,10 +157,19 @@ def _anthropic_create(model, messages):
         raise RuntimeError(
             f"non-JSON response from relay (HTTP {status}, {len(body_bytes)} bytes): {snippet!r}"
         ) from exc
-    # Anthropic content is a list of blocks; concatenate text blocks.
-    text = "".join(c.get("text", "") for c in data.get("content", []) if c.get("type") == "text")
+    # Keep thinking blocks for the trace, but only text blocks form the response.
+    content = data.get("content", []) or []
+    text = "".join(c.get("text", "") for c in content if c.get("type") == "text")
+    thinking_blocks = [
+        c for c in content
+        if c.get("type") in {"thinking", "redacted_thinking"}
+    ]
     usage = data.get("usage", {}) or {}
-    return text, usage
+    reasoning = (
+        {"provider_format": "anthropic-messages", "blocks": thinking_blocks}
+        if thinking_blocks else None
+    )
+    return text, usage, reasoning
 
 
 def _http_status_from_exc(exc):
@@ -174,7 +194,7 @@ def _read_error_body(exc, limit=800):
 
 
 def _retry_create(client, model, messages):
-    """Call the LLM with retries. Returns (text, usage_dict).
+    """Call the LLM with retries. Returns (text, usage_dict, reasoning_payload).
 
     - Anthropic-family models go via the native /v1/messages endpoint.
     - Other models go through the OpenAI-compat client.
@@ -182,7 +202,8 @@ def _retry_create(client, model, messages):
       third-party relays that support it can keep prompt-cache routing sticky.
     """
     if is_cli_backend_enabled():
-        return run_agent_for_messages(model, messages)
+        text, usage = run_agent_for_messages(model, messages)
+        return text, usage, None
 
     rate_limit_attempts = 0
     transient_attempts = 0
@@ -195,9 +216,10 @@ def _retry_create(client, model, messages):
             if use_anthropic:
                 return _anthropic_create(model, messages)
             response = client.chat.completions.create(model=model, messages=messages, **extra)
-            text = response.choices[0].message.content
+            message = response.choices[0].message
+            text = message.content
             usage = response.usage.model_dump() if response.usage else {}
-            return text, usage
+            return text, usage, _openai_reasoning_payload(message)
         except BadRequestError:
             raise
         except urllib.error.HTTPError as exc:
@@ -304,8 +326,9 @@ def _llm_json_call(client, model, messages, validator, schema_description,
         started = utc_now_iso()
         response = None
         usage = {}
+        reasoning = None
         try:
-            response, usage = _retry_create(client, model, messages)
+            response, usage, reasoning = _retry_create(client, model, messages)
         except Exception as exc:
             event = {
                 "event_id": event_id,
@@ -353,7 +376,7 @@ def _llm_json_call(client, model, messages, validator, schema_description,
                 "parse_error": parse_error,
             },
         }
-        record_llm_exchange(trace_dir, event_id, event, messages, response)
+        record_llm_exchange(trace_dir, event_id, event, messages, response, reasoning)
         if status == "success":
             return result
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -297,8 +297,11 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
         started = utc_now_iso()
         response = None
         usage = {}
+        reasoning = None
         try:
-            response, usage = _retry_create(_llm_provider_client, REASONER_SPEC_CHECK_MODEL, messages)
+            response, usage, reasoning = _retry_create(
+                _llm_provider_client, REASONER_SPEC_CHECK_MODEL, messages
+            )
         except Exception as exc:
             event = {
                 "event_id": event_id,
@@ -346,7 +349,7 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
                 "parse_error": parse_error,
             },
         }
-        record_llm_exchange(trace_dir, event_id, event, messages, response)
+        record_llm_exchange(trace_dir, event_id, event, messages, response, reasoning)
         if has_violation is not None:
             if has_violation:
                 stmts = stmts or "(unable to extract)"

--- a/src/trace_writer.py
+++ b/src/trace_writer.py
@@ -43,7 +43,7 @@ def append_event(trace_dir, event):
             f.write(line + "\n")
 
 
-def record_llm_exchange(trace_dir, event_id, event, messages, response=None):
+def record_llm_exchange(trace_dir, event_id, event, messages, response=None, reasoning=None):
     if not trace_dir:
         return
 
@@ -77,6 +77,18 @@ def record_llm_exchange(trace_dir, event_id, event, messages, response=None):
             {
                 "type": "assistant_output",
                 "content_ref": write_payload(trace_dir, event_id, "response.txt", response),
+            }
+        )
+    if reasoning is not None:
+        children.append(
+            {
+                "type": "assistant_reasoning",
+                "content_ref": write_payload(
+                    trace_dir,
+                    event_id,
+                    "reasoning.json",
+                    json.dumps(reasoning, ensure_ascii=False),
+                ),
             }
         )
     metadata.pop("parsed", None)


### PR DESCRIPTION
## Summary

This PR saves provider-returned LLM reasoning data in FM-Agent execution traces.

Previously, direct verification calls stored the prompts and final text response, but discarded reasoning data returned by OpenAI-compatible or Anthropic-compatible providers. This PR adds a separate reasoning payload to the trace without changing the model request, structured-output parsing, retry behavior, or verification result.

## Changes

- Added OpenAI-compatible reasoning extraction in `src/llm_client.py`.
  - Records only the supported response fields:
    - `reasoning_content`
    - `reasoning`
    - `reasoning_details`
  - Does not save unrelated provider-specific response fields.
  - Does not modify `message.content`, which remains the only source of the final response text.

- Updated Anthropic-native response handling in `src/llm_client.py`.
  - Continues to build the final response from `text` content blocks only.
  - Preserves returned `thinking` and `redacted_thinking` blocks separately for trace output.
  - Keeps block fields such as Anthropic thinking signatures unchanged in the saved payload.

- Extended the internal `_retry_create` result from:
  ```python
  (text, usage)
  ```
  to:
  ```python
  (text, usage, reasoning)
  ```
  - CLI backends return `reasoning=None`, so their existing text-based protocol is unchanged.
  - OpenAI-compatible and Anthropic-native backends return reasoning only when the provider included it in the response.

- Updated both direct LLM verification paths:
  - `_llm_json_call`
  - `_check_post_implies_spec`

  These paths now pass the optional reasoning payload to trace writing. Reasoning is not passed to JSON parsing, validators, retry messages, or later LLM requests.

- Extended `record_llm_exchange` in `src/trace_writer.py`.
  - When reasoning exists, it writes:
    ```text
    fm_agent/trace/payloads/<event_id>_reasoning.json
    ```
  - The matching `events.jsonl` event receives a child entry:
    ```json
    {
      "type": "assistant_reasoning",
      "content_ref": "trace/payloads/<event_id>_reasoning.json"
    }
    ```
  - When no reasoning is returned, no additional payload file or child entry is created.

## Result

For providers that already return reasoning data, each LLM trace can now contain:

```text
fm_agent/trace/payloads/<event_id>_response.txt
fm_agent/trace/payloads/<event_id>_reasoning.json
```

The response file continues to contain the final answer used by FM-Agent. The reasoning file contains only the provider-returned reasoning payload and can be used to investigate reasoning-related verification behavior.