### PR TITLE
feat: add --dashboard option to main command

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,14 @@ FM-Agent ships a standalone real-time TUI dashboard ([dashboard.py](dashboard.py
 uv run python dashboard.py <proj_dir>
 ```
 
+Alternatively, start it automatically from the main command; it monitors the
+current run's workspace (including isolated runs) and is stopped when the run
+finishes:
+
+```bash
+uv run python main.py <proj_dir> --dashboard
+```
+
 To generate and display only the pre-run estimate, without starting the
 pipeline or making LLM calls:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -290,6 +290,12 @@ FM-Agent 自带一个独立的实时 TUI 监控面板（[dashboard.py](dashboard
 uv run python dashboard.py <proj_dir>
 ```
 
+也可以直接在主命令中启用，Dashboard 会自动关联本次运行的工作目录，并在流水线结束时退出：
+
+```bash
+uv run python main.py <proj_dir> --dashboard
+```
+
 如需在不启动流水线、不调用 LLM 的情况下生成并展示一次运行前估算：
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ import time
 import shutil
 import logging
 import contextlib
+import subprocess
 
 
 def _clean_previous_run(work_dir):
@@ -122,6 +123,29 @@ def _resolve_bug_validator_path(raw_path):
         ) from exc
 
     return path
+
+
+def _start_dashboard(work_dir):
+    """Start the live dashboard for this run and return its process handle."""
+    dashboard_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dashboard.py")
+    try:
+        return subprocess.Popen([sys.executable, dashboard_path, work_dir])
+    except Exception as exc:
+        logging.warning("[Pipeline] dashboard failed to start: %s", exc)
+        return None
+
+
+def _stop_dashboard(process):
+    if process is None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=3)
+    except Exception:
+        try:
+            process.kill()
+        except Exception:
+            pass
 
 
 def _normalize_submodules(proj_dir, submodules):
@@ -562,6 +586,7 @@ if __name__ == "__main__":
               "[--submodule PATH [PATH ...]] [--entry-func PATH [PATH ...]] "
               "[--end-func PATH ...] [--extra-edge FILE] "
               "[--bug-validator FILE] [--only-spec] [--estimate] "
+              "[--dashboard] "
               "[--list-plugin] [--plugin NAME]",
         description="Run the FM agent pipeline on a project directory.",
     )
@@ -608,6 +633,11 @@ if __name__ == "__main__":
         action="store_true",
         help="scan source scope and print a history-based run estimate without "
         "starting the pipeline or making LLM calls",
+    )
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="automatically start the live dashboard for this run",
     )
     parser.add_argument(
         "--domain-knowledge",
@@ -752,13 +782,14 @@ if __name__ == "__main__":
                 args.isolate,
                 args.only_spec,
                 args.all_bugs,
+                args.dashboard,
             ]
         )
         if incompatible:
             parser.error(
                 "--estimate is a standalone preflight and cannot be combined "
                 "with resume, incremental, entry/end functions, isolate, "
-                "only-spec, or all-bugs"
+                "only-spec, all-bugs, or dashboard"
             )
         estimate_work_dir = os.path.join(proj_dir, "fm_agent_estimate")
         estimate = write_preflight_estimate(
@@ -782,18 +813,22 @@ if __name__ == "__main__":
 
     # Entry-point mode uses its dedicated copy-and-trim pipeline.
     if args.entry_func is not None:
-        run_entry_pipeline(
-            proj_dir,
-            entry_func=args.entry_func,
-            end_funcs=args.end_func,
-            resume=resume,
-            domain_knowledge_files=domain_knowledge_files,
-            one_phase=args.one_phase,
-            extra_call_edges_path=extra_call_edges_path,
-            only_spec=args.only_spec,
-            bug_validator_path=bug_validator_path,
-            all_bugs=args.all_bugs,
-        )
+        dashboard_process = _start_dashboard(proj_dir) if args.dashboard else None
+        try:
+            run_entry_pipeline(
+                proj_dir,
+                entry_func=args.entry_func,
+                end_funcs=args.end_func,
+                resume=resume,
+                domain_knowledge_files=domain_knowledge_files,
+                one_phase=args.one_phase,
+                extra_call_edges_path=extra_call_edges_path,
+                only_spec=args.only_spec,
+                bug_validator_path=bug_validator_path,
+                all_bugs=args.all_bugs,
+            )
+        finally:
+            _stop_dashboard(dashboard_process)
         end_time = time.time()
         logging.info(f"Total time: {end_time - start_time:.2f} seconds")
         sys.exit(0)
@@ -844,6 +879,7 @@ if __name__ == "__main__":
         else None
     )
     with run_ctx as run_dir:
+        dashboard_process = _start_dashboard(run_dir) if args.dashboard else None
         try:
             # Incremental mode requires a recorded commit to diff against; without a
             # version.log from a previous run, fall back to the full pipeline.
@@ -884,6 +920,7 @@ if __name__ == "__main__":
                 duration_seconds=time.time() - start_time,
             )
         finally:
+            _stop_dashboard(dashboard_process)
             # With --isolate the pipeline ran against a throwaway snapshot, so its
             # fm_agent/ results live in the snapshot. Copy them back into the real
             # project so they are not lost when the snapshot is discarded — this runs


### PR DESCRIPTION
## Summary
- add a lightweight `--dashboard` flag to `main.py`
- automatically monitor the active run workspace, including isolated runs
- stop the dashboard when the pipeline exits
- document the new invocation in English and Chinese README files

Closes #226

## Verification
- `python3 -m py_compile main.py dashboard.py`
- `git diff --check